### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/kill.yml
+++ b/.github/workflows/kill.yml
@@ -2,6 +2,9 @@ name: Kill Docker Container
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/KRKleinberg/Jace/security/code-scanning/1](https://github.com/KRKleinberg/Jace/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow does not appear to interact with the repository (e.g., no actions like creating issues, modifying contents, or triggering workflows), we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the `GITHUB_TOKEN` has restricted access, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
